### PR TITLE
fix pin number 4 of actual pin 2,4 to 2 to match component SCHDPAK

### DIFF
--- a/D-Pak_TO252AA.kicad_mod
+++ b/D-Pak_TO252AA.kicad_mod
@@ -1,4 +1,4 @@
-(module D-Pak_TO252AA (layer F.Cu) (tedit 552FE2A5)
+(module D-Pak_TO252AA (layer F.Cu) (tedit 55E4435C)
   (descr "D-Pak, TO252AA, Diode")
   (tags "D-Pak TO252AA Diode")
   (attr smd)
@@ -13,7 +13,7 @@
   (fp_line (start 3.65 5.95) (end -3.65 5.95) (layer F.CrtYd) (width 0.05))
   (fp_line (start -3.65 5.95) (end -3.65 -5.95) (layer F.CrtYd) (width 0.05))
   (pad 3 smd rect (at 2.18 4.3) (size 1.55 2.78) (layers F.Cu F.Paste F.Mask))
-  (pad 4 smd rect (at 0 -2.335) (size 6.74 6.73) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at 0 -2.335) (size 6.74 6.73) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -2.18 4.3) (size 1.55 2.78) (layers F.Cu F.Paste F.Mask))
   (model Diodes_SMD.3dshapes/D-Pak_TO252AA.wrl
     (at (xyz 0 0 0))


### PR DESCRIPTION
Component SCHDPAK uses pins 2 and 1,3 in schematic,
while footprint D-Pak_TO252AA uses pins 4 and 1,3 
imho this looks like a typo that need's fixing :)