### PR TITLE
Add "DO-214Ax" to all SMx diode descriptions

### DIFF
--- a/D_SMA-SMB_Universal_Handsoldering.kicad_mod
+++ b/D_SMA-SMB_Universal_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMA-SMB_Universal_Handsoldering (layer F.Cu) (tedit 5864381A)
-  (descr "Diode, Universal, SMA, SMB, Handsoldering,")
-  (tags "Diode Universal SMA SMB Handsoldering ")
+  (descr "Diode, Universal, SMA (DO-214AC) or SMB (DO-214AA), Handsoldering,")
+  (tags "Diode Universal SMA (DO-214AC) SMB (DO-214AA) Handsoldering ")
   (attr smd)
   (fp_text reference REF** (at 0 -3) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMA.kicad_mod
+++ b/D_SMA.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMA (layer F.Cu) (tedit 586432E5)
-  (descr "Diode SMA")
-  (tags "Diode SMA")
+  (descr "Diode SMA (DO-214AC)")
+  (tags "Diode SMA (DO-214AC)")
   (attr smd)
   (fp_text reference REF** (at 0 -2.5) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMA_Handsoldering.kicad_mod
+++ b/D_SMA_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMA_Handsoldering (layer F.Cu) (tedit 58643398)
-  (descr "Diode SMA Handsoldering")
-  (tags "Diode SMA Handsoldering")
+  (descr "Diode SMA (DO-214AC) Handsoldering")
+  (tags "Diode SMA (DO-214AC) Handsoldering")
   (attr smd)
   (fp_text reference REF** (at 0 -2.5) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMB-SMC_Universal_Handsoldering.kicad_mod
+++ b/D_SMB-SMC_Universal_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMB-SMC_Universal_Handsoldering (layer F.Cu) (tedit 586436A6)
-  (descr "Diode, Universal, SMB, SMC, Handsoldering,")
-  (tags "Diode Universal SMB SMC Handsoldering ")
+  (descr "Diode, Universal, SMB(DO-214AA) or SMC (DO-214AA), Handsoldering,")
+  (tags "Diode Universal SMB(DO-214AA) SMC (DO-214AA) Handsoldering ")
   (attr smd)
   (fp_text reference REF** (at 0 -4.1) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMB-SMC_Universal_Handsoldering.kicad_mod
+++ b/D_SMB-SMC_Universal_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMB-SMC_Universal_Handsoldering (layer F.Cu) (tedit 586436A6)
-  (descr "Diode, Universal, SMB(DO-214AA) or SMC (DO-214AA), Handsoldering,")
-  (tags "Diode Universal SMB(DO-214AA) SMC (DO-214AA) Handsoldering ")
+  (descr "Diode, Universal, SMB(DO-214AA) or SMC (DO-214AB), Handsoldering,")
+  (tags "Diode Universal SMB(DO-214AA) SMC (DO-214AB) Handsoldering ")
   (attr smd)
   (fp_text reference REF** (at 0 -4.1) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMB.kicad_mod
+++ b/D_SMB.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMB (layer F.Cu) (tedit 58645DF3)
-  (descr "Diode SMB")
-  (tags "Diode SMB")
+  (descr "Diode SMB (DO-214AA)")
+  (tags "Diode SMB (DO-214AA)")
   (attr smd)
   (fp_text reference REF** (at 0 -3) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMB_Handsoldering.kicad_mod
+++ b/D_SMB_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMB_Handsoldering (layer F.Cu) (tedit 590B3D55)
-  (descr "Diode SMB Handsoldering")
-  (tags "Diode SMB Handsoldering")
+  (descr "Diode SMB (DO-214AA) Handsoldering")
+  (tags "Diode SMB (DO-214AA) Handsoldering")
   (attr smd)
   (fp_text reference REF** (at 0 -3) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMC-RM10_Universal_Handsoldering.kicad_mod
+++ b/D_SMC-RM10_Universal_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMC-RM10_Universal_Handsoldering (layer F.Cu) (tedit 58643524)
-  (descr "Diode, Universal, SMC, RM10, Handsoldering, SMD, Thruhole, = DO-214AB")
-  (tags "Diode Universal SMC RM10 Handsoldering SMD Thruhole DO-214AB ")
+  (descr "Diode, Universal, SMC (DO-214AB), RM10, Handsoldering, SMD, Thruhole")
+  (tags "Diode Universal SMC (DO-214AB) RM10 Handsoldering SMD Thruhole")
   (fp_text reference REF** (at 0 -4.1) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )

--- a/D_SMC.kicad_mod
+++ b/D_SMC.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMC (layer F.Cu) (tedit 5864295D)
-  (descr "Diode SMC = DO-214AB")
-  (tags "Diode SMC DO-214AB")
+  (descr "Diode SMC (DO-214AB)")
+  (tags "Diode SMC (DO-214AB)")
   (attr smd)
   (fp_text reference REF** (at 0 -4.1) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMC_Handsoldering.kicad_mod
+++ b/D_SMC_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMC_Handsoldering (layer F.Cu) (tedit 58642B03)
-  (descr "Diode SMC Handsoldering (DO-214AB)")
-  (tags "Diode SMC Handsoldering (DO-214AB)")
+  (descr "Diode SMC (DO-214AB) Handsoldering")
+  (tags "Diode SMC (DO-214AB) Handsoldering")
   (attr smd)
   (fp_text reference REF** (at 0 -4.1) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/D_SMC_Handsoldering.kicad_mod
+++ b/D_SMC_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_SMC_Handsoldering (layer F.Cu) (tedit 58642B03)
-  (descr "Diode SMC Handsoldering = DO-214AB")
-  (tags "Diode SMC Handsoldering DO-214AB")
+  (descr "Diode SMC Handsoldering (DO-214AB)")
+  (tags "Diode SMC Handsoldering (DO-214AB)")
   (attr smd)
   (fp_text reference REF** (at 0 -4.1) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))


### PR DESCRIPTION
Just as it says. Only description updates to make searching easier and provide both package names.